### PR TITLE
Add speed and course to returned location

### DIFF
--- a/HCKalmanFilter/HCKalmanAlgorithm.swift
+++ b/HCKalmanFilter/HCKalmanAlgorithm.swift
@@ -241,8 +241,14 @@ open class HCKalmanAlgorithm
         let lon = xk1.matrix[2,0]
         let altitude = xk1.matrix[4,0]
         
-        let kalmanCLLocation = CLLocation(coordinate: CLLocationCoordinate2D(latitude: lat,longitude: lon), altitude: altitude, horizontalAccuracy: self.previousLocation.horizontalAccuracy, verticalAccuracy: self.previousLocation.verticalAccuracy, timestamp: previousMeasureTime)
-        
+        let kalmanCLLocation = CLLocation(coordinate: CLLocationCoordinate2D(latitude: lat,longitude: lon),
+                                          altitude: altitude,
+                                          horizontalAccuracy: self.previousLocation.horizontalAccuracy,
+                                          verticalAccuracy: self.previousLocation.verticalAccuracy,
+                                          course: self.previousLocation.course,
+                                          speed: self.previousLocation.speed,
+                                          timestamp: previousMeasureTime)
+                                          
         return kalmanCLLocation
     }
 }


### PR DESCRIPTION
# Overview
A returned location from the `process()` function will now include the speed and course from the raw location that was passed.